### PR TITLE
fix: adjust types for Fontsource config

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -108,13 +108,18 @@ export interface CustomFonts {
   stripPrefix?: string
 }
 
-export interface FontsourceFontFamily {
+interface BaseFontsourceFontFamily {
   name: string
-  variables?: ('variable' | 'variable-italic' | 'variable-full' | 'variable-full-italic')[]
-  weights: (100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900)[]
   styles?: ('italic' | 'normal')[]
   subset?: string
 }
+interface WeightsFontsourceFontFamily extends BaseFontsourceFontFamily {
+  weights: (100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900)[]
+}
+interface VariableFontsourceFontFamily extends BaseFontsourceFontFamily {
+  variables: ('variable' | 'variable-italic' | 'variable-full' | 'variable-full-italic')[]
+}
+export type FontsourceFontFamily = WeightsFontsourceFontFamily | VariableFontsourceFontFamily
 export interface FontsourceFonts {
   families: (string | FontsourceFontFamily)[]
 }


### PR DESCRIPTION
Hello 👋🏼 ,
Currently it's required to provide `weights` field to Fontsource family config. However, when using variable fonts providing `variables` field is enough and you even get a warning if you provide both of them. I've adjusted the types so it reflect the behavior better.

<img width="1089" alt="image" src="https://user-images.githubusercontent.com/54995479/230361557-e145ab86-39d7-458f-a256-c2942ea2ab39.png">

<img width="553" alt="image" src="https://user-images.githubusercontent.com/54995479/230362881-dcb95e06-e78a-4e8a-8073-bfec12ae68a5.png">
