### PR TITLE
Fixes bug in `fontsource.ts` when style is normal

### DIFF
--- a/src/loaders/fontsource.ts
+++ b/src/loaders/fontsource.ts
@@ -29,7 +29,7 @@ export function fontsourceVirtualModule(options?: FontsourceFonts) {
         if (family.styles) {
           for (const style of family.styles) {
             if (style === 'normal')
-              source.push(`@import "@fontsource/${name}/${subsetPrefix}${style}.css";`)
+              source.push(`@import "@fontsource/${name}/${subsetPrefix}${weight}.css";`)
             else
               source.push(`@import "@fontsource/${name}/${subsetPrefix}${weight}-${style}.css";`)
           }


### PR DESCRIPTION
### Problem
Currently, the plugin configuration

```js
Unfonts({
  fontsource: {
    families: [
      {
        name: 'Roboto',
        weights: [400],
        styles: ['normal', 'italic'],
        subset: 'latin',
      },
    ],
  },
}),
```
generates an error:

```yaml
[vite:css] [postcss] ENOENT: no such file or directory, open '@fontsource/roboto/latin-normal.css'
file: unfonts.css:undefined:undefined
error during build:
Error: [postcss] ENOENT: no such file or directory, open '@fontsource/roboto/latin-normal.css'
```

### Expected Solution
The configuration should lead to the successful loading of the following files:

```less
@fontsource/roboto/latin-400.css
@fontsource/roboto/latin-400-italic.css
```
If the style is set to `normal`, the style should not be included in the file name; instead, the weight should be retained.
