### PR TITLE
docs: add step for adding font links in svelte:head to sveltekit installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,17 @@ export default defineConfig({
     })
   ]
 })
+
+// +layout.svelte
+<script>
+  import { links } from 'unplugin-fonts/head'
+</script>
+
+<svelte:head>
+	{#each links as link}
+    <link {...link?.attrs || {}} />
+	{/each}
+</svelte:head>
 ```
 
 Example: [`examples/sveltekit`](./examples/sveltekit)

--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ export default defineConfig({
 </script>
 
 <svelte:head>
-	{#each links as link}
+  {#each links as link}
     <link {...link?.attrs || {}} />
-	{/each}
+  {/each}
 </svelte:head>
 ```
 


### PR DESCRIPTION
When trying to implement `unplugin-fonts` into my SvelteKit project today, I followed the provided instructions but continually experienced issues with my fonts not displaying. 

After some troubleshooting, I discovered that due to [SvelteKit not using transformIndexHtml vite process](https://github.com/sveltejs/kit/discussions/7324), the automatic addition of font links from `vite.config.js(ts)` based on the `injectTo` parameter isn't possible. 

The workaround solution for this is to add the following code into `+layout.svelte` (or another preferred location):

```svelte
<script>
  import { links } from 'unplugin-fonts/head'
</script>

<svelte:head>
  {#each links as link}
    <link {...link?.attrs || {}} />
  {/each}
</svelte:head>
```

This snippet is currently utilized in an existing SvelteKit [example](https://github.com/cssninjaStudio/unplugin-fonts/blob/main/examples/sveltekit/src/routes/%2Blayout.svelte), however, it's not explicitly mentioned in the instructions that this is a necessary step.

In this PR, I have included mention of this code snippet in the instructions for adding the plugin to a SvelteKit project. I believe that this will prevent similar issues from occurring amongst other users.