### PR TITLE
Introduce link tag filter hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,16 @@ export default createUnplugin<Options | undefined>((userOptions) => {
               },
             })
           }
-          return tags
+          let tagsReturned = tags
+          if (options?.custom?.linkFilter) {
+            const newTags: object[] | boolean = options?.custom?.linkFilter(tags)
+            if (Array.isArray(newTags)) {
+              tagsReturned = newTags
+            } else {
+              tagsReturned = newTags ? tags : []
+            }
+          }
+          return tagsReturned
         },
       },
     },
@@ -149,7 +158,17 @@ function generateVitepressBundle(
     })
   }
 
-  for (const tag of tags) {
+  let tagsReturned = tags
+  if (options?.custom?.linkFilter) {
+    const newTags: object[] | boolean = options?.custom?.linkFilter(tags)
+    if (Array.isArray(newTags)) {
+      tagsReturned = newTags
+    } else {
+      tagsReturned = newTags ? tags : []
+    }
+  }
+
+  for (const tag of tagsReturned) {
     vitepressConfig?.site?.head?.push([
       tag.tag,
       tag.attrs?.onload === 'this.rel=\'stylesheet\''

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,13 @@ export default createUnplugin<Options | undefined>((userOptions) => {
         handler: (html, ctx) => {
           const tags = getHeadLinkTags(options)
           const files = Object.keys(ctx.bundle ?? {}).filter(key => fontFileRegex.test(key))
+          const { prefetch: wantPrefetch, preload: wantPreload } = options?.custom || {}
           for (const file of files) {
+            if (!(
+              wantPrefetch === true || wantPreload === true ||
+              (wantPrefetch === undefined && wantPreload === undefined)
+            ))
+              continue
             const ext = extname(file)
             tags.push({
               tag: 'link',
@@ -121,7 +127,14 @@ function generateVitepressBundle(
 
   const tags = getHeadLinkTags(options)
   const files = Object.keys(bundle ?? {}).filter(key => fontFileRegex.test(key))
+  const { prefetch: wantPrefetch, preload: wantPreload } = options?.custom || {}
   for (const file of files) {
+    if (!(
+      wantPrefetch === true || wantPreload === true ||
+      (wantPrefetch === undefined && wantPreload === undefined)
+    ))
+      continue
+
     const ext = extname(file)
     tags.push({
       tag: 'link',

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,6 +98,13 @@ export interface CustomFonts {
   prefetch?: boolean
   prefetchPrefix?: string
   /**
+   * Provides a hook for filtering which `<link>` tags should be actually
+   * generated.
+   * @default true
+   */
+  linkFilter?: (tags: object[]) => object[] | boolean
+
+  /**
    * @default: 'head-prepend'
    */
   injectTo?: 'head' | 'body' | 'head-prepend' | 'body-prepend'


### PR DESCRIPTION
This PR introduces a new hook to allow the user to modify or supress individual or all link tags generated by this plugin.

As I'm rarely working with JS/TS, I'm glad about feedback on the code. The PR was drafted in a few minutes. I only gauged the code to look fine; I didn't run it … ;-)

Fixes: #7, #10, #70